### PR TITLE
fix IUserRepository dependency to createStripeModule

### DIFF
--- a/src/di/modules/create-stripe-module.ts
+++ b/src/di/modules/create-stripe-module.ts
@@ -18,6 +18,7 @@ export const createStripeModule = () => {
     .toHigherOrderFunction(stripeCreateCheckoutSessionIdAsClientUseCase, [
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.IStripeService,
+      DI_SYMBOLS.IUserRepository,
     ]);
 
   stripeModule


### PR DESCRIPTION
This pull request includes a small change to the `src/di/modules/create-stripe-module.ts` file. The change adds a new dependency to the `createStripeModule` function to include the `IUserRepository` service.

* [`src/di/modules/create-stripe-module.ts`](diffhunk://#diff-2aac7a023c62d32ea5220fbc265ef04b523bdf0a6e974046d206b787a3937cc7R21): Added `DI_SYMBOLS.IUserRepository` to the list of dependencies in the `createStripeModule` function.